### PR TITLE
Properly cache svg files in `svg_path`

### DIFF
--- a/src/pyconify/api.py
+++ b/src/pyconify/api.py
@@ -231,14 +231,24 @@ def svg_path(
 
     Arguments are the same as for `pyconfify.api.svg` except for `dir` which is the
     directory to save the SVG file to (it will be passed to `tempfile.mkstemp`).
+    To have permanen cache under custom localisation one need to set 
+    PYCONIFY_CACHE environment variable befor import pyconify. 
     """
-    # first look for SVG file in cache
-    if dir is None:
+
+    # if there is no request to store outside cache 
+    # and default cache is not disabled then get it from cache
+    if dir is None and :
         *_, svg_cache_key = _svg_keys(key, locals())
+        if svg_cache_key not in svg_cache():
+            # if required fetch the svg from server
+            svg(
+                *key, color=color, height=height, width=width, flip=flip, rotate=rotate, box=box
+            )
         if path := _svg_path(svg_cache_key):
             # if it exists return that string
+            # this may fail if cache is disabled globally
             return path
-
+         
     # otherwise, we need to download it and save it to a temporary file
     svg_bytes = svg(
         *key, color=color, height=height, width=width, flip=flip, rotate=rotate, box=box


### PR DESCRIPTION
This is bugfix PR. Currently if cache is enabled but, icon is not downloaded yet, the obsolete temporary file is created and proper cached file is used since next run. This PR fix this by prefetch data if they are missed in cache struct. 
