### PR TITLE
feat: delay import of requests,  drop python 3.8, add python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
         include:
-          - python-version: "3.8"
+          - python-version: "3.9"
             os: windows-latest
-          - python-version: "3.8"
+          - python-version: "3.9"
             os: macos-latest
 
   test-qt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,17 +12,17 @@ name = "pyconify"
 dynamic = ["version"]
 description = "iconify for python. Universal icon framework"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }
 authors = [{ name = "Talley Lambert", email = "talley.lambert@gmail.com" }]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: BSD License",
     "Typing :: Typed",
 ]
@@ -36,44 +36,38 @@ dev = ["black", "ipython", "mypy", "pdbpp", "rich", "ruff", "types-requests"]
 homepage = "https://github.com/pyapp-kit/pyconify"
 repository = "https://github.com/pyapp-kit/pyconify"
 
-# https://github.com/charliermarsh/ruff
+# https://beta.ruff.rs/docs/rules/
 [tool.ruff]
 line-length = 88
-target-version = "py38"
-# https://beta.ruff.rs/docs/rules/
+target-version = "py39"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+pydocstyle = { convention = "numpy" }
 select = [
-    "E",    # style errors
     "W",    # style warnings
+    "E",    # style errors
     "F",    # flakes
     "D",    # pydocstyle
     "I",    # isort
     "UP",   # pyupgrade
-    "C",    # flake8-comprehensions
-    "B",    # flake8-bugbear
-    "A001", # flake8-builtins
+    "S",    # bandit
+    "C4",   # comprehensions
+    "B",    # bugbear
+    "A001", # Variable shadowing a python builtin
+    "TC",   # flake8-type-checking
+    "TID",  # flake8-tidy-imports
     "RUF",  # ruff-specific rules
-    "TCH",
-    "TID",
+    "PERF", # performance
+    "SLF",  # private access
 ]
-
-# I do this to get numpy-style docstrings AND retain
-# D417 (Missing argument descriptions in the docstring)
-# otherwise, see:
-# https://beta.ruff.rs/docs/faq/#does-ruff-support-numpy-or-google-style-docstrings
-# https://github.com/charliermarsh/ruff/issues/2606
 ignore = [
     "D100", # Missing docstring in public module
-    "D107", # Missing docstring in __init__
-    "D203", # 1 blank line required before class docstring
-    "D212", # Multi-line docstring summary should start at the first line
-    "D213", # Multi-line docstring summary should start at the second line
-    "D401", # First line should be in imperative mood
-    "D413", # Missing blank line after last section
-    "D416", # Section name should end with a colon
+    "D401", # First line should be in imperative mood (remove to opt in)
 ]
 
-[tool.ruff.per-file-ignores]
-"tests/*.py" = ["D"]
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = ["D", "S101", "E501", "SLF"]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]

--- a/src/pyconify/_cache.py
+++ b/src/pyconify/_cache.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator, MutableMapping
 from contextlib import suppress
 from pathlib import Path
-from typing import Iterator, MutableMapping
 
 _SVG_CACHE: MutableMapping[str, bytes] | None = None
 PYCONIFY_CACHE: str = os.environ.get("PYCONIFY_CACHE", "")
@@ -36,7 +36,7 @@ def clear_cache() -> None:
     global _SVG_CACHE
     _SVG_CACHE = None
     with suppress(AttributeError):
-        svg_path.cache_clear()  # type: ignore
+        svg_path.cache_clear()
 
 
 def get_cache_directory(app_name: str = "pyconify") -> Path:

--- a/src/pyconify/freedesktop.py
+++ b/src/pyconify/freedesktop.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import atexit
 import shutil
+from collections.abc import Mapping
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from pyconify.api import svg
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import shutil
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,8 +7,7 @@ import pytest
 import requests
 
 import pyconify
-from pyconify import _cache
-from pyconify import api
+from pyconify import _cache, api
 from pyconify._cache import _SVGCache, clear_cache, get_cache_directory
 
 
@@ -82,8 +81,7 @@ def test_cache_used_offline() -> None:
     with internet_offline():
         # make sure the patch works
         with pytest.raises(requests.ConnectionError):
-            x = pyconify.svg_path("mdi:pencil-plus-outline")
-            breakpoint()
+            pyconify.svg_path("mdi:pencil-plus-outline")
 
         # make sure the cached icon works
         svg2 = pyconify.svg_path("mdi:pen-add", color="#333333")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -8,6 +8,7 @@ import requests
 
 import pyconify
 from pyconify import _cache
+from pyconify import api
 from pyconify._cache import _SVGCache, clear_cache, get_cache_directory
 
 
@@ -62,8 +63,8 @@ def test_tmp_svg_with_fixture() -> None:
 @contextmanager
 def internet_offline() -> Iterator[None]:
     """Simulate an offline internet connection."""
-
-    with patch.object(requests, "get") as mock:
+    session = api._session()
+    with patch.object(session, "get") as mock:
         mock.side_effect = requests.ConnectionError("No internet connection.")
         # clear functools caches...
         for val in vars(pyconify).values():
@@ -81,7 +82,8 @@ def test_cache_used_offline() -> None:
     with internet_offline():
         # make sure the patch works
         with pytest.raises(requests.ConnectionError):
-            pyconify.svg_path("mdi:pencil-plus-outline")
+            x = pyconify.svg_path("mdi:pencil-plus-outline")
+            breakpoint()
 
         # make sure the cached icon works
         svg2 = pyconify.svg_path("mdi:pen-add", color="#333333")

--- a/tests/test_pyconify.py
+++ b/tests/test_pyconify.py
@@ -98,14 +98,15 @@ def test_keywords() -> None:
     with pytest.warns(UserWarning, match="Cannot specify both prefix and keyword"):
         assert isinstance(pyconify.keywords("home", keyword="home"), dict)
 
-    assert pyconify.keywords()
+    with pytest.raises(OSError):
+        pyconify.keywords()
 
 
 def test_search() -> None:
     result = pyconify.search("arrow", prefixes={"bi"}, limit=10, start=2)
     assert result["collections"]
 
-    result = pyconify.search("arrow", prefixes="bi", category="General")
+    result = pyconify.search("home", prefixes="material-symbols", category="Material")
     assert result["collections"]
 
 


### PR DESCRIPTION
related to https://github.com/pyapp-kit/superqt/pull/270

this delays importing requests until a session is actually needed (i.e. a cached svg is not available)

it also drops python 3.8 and adds 3.13