### PR TITLE
feat: add ability to clear/cap cache size

### DIFF
--- a/src/pyconify/__init__.py
+++ b/src/pyconify/__init__.py
@@ -10,6 +10,7 @@ except PackageNotFoundError:  # pragma: no cover
 __author__ = "Talley Lambert"
 __email__ = "talley.lambert@gmail.com"
 __all__ = [
+    "clear_api_cache",
     "clear_cache",
     "collection",
     "collections",
@@ -21,12 +22,14 @@ __all__ = [
     "keywords",
     "last_modified",
     "search",
+    "set_api_cache_maxsize",
     "svg",
     "svg_path",
 ]
 
 from ._cache import clear_cache, get_cache_directory
 from .api import (
+    clear_api_cache,
     collection,
     collections,
     css,
@@ -35,6 +38,7 @@ from .api import (
     keywords,
     last_modified,
     search,
+    set_api_cache_maxsize,
     svg,
     svg_path,
 )

--- a/tests/test_pyconify.py
+++ b/tests/test_pyconify.py
@@ -112,3 +112,14 @@ def test_search() -> None:
 
 def test_iconify_version() -> None:
     assert isinstance(pyconify.iconify_version(), str)
+
+
+def test_clear_api_cache() -> None:
+    assert pyconify.collections.cache_info().currsize > 0
+    assert pyconify.collections.cache_info().maxsize == 128
+
+    pyconify.clear_api_cache()
+    pyconify.set_api_cache_maxsize(10)
+
+    assert pyconify.collections.cache_info().currsize == 0
+    assert pyconify.collections.cache_info().maxsize == 10


### PR DESCRIPTION
fixes #30 

@aditya306b, let me know if this would work for you



### New caching functionalities:

* Added `clear_api_cache` function to clear all cached responses to the Iconify API from the current session in `src/pyconify/api.py`.
* Added `set_api_cache_maxsize` function to set the `lru_cache` max size for all API calls and clear the cache in `src/pyconify/api.py`.

### Updates to existing cache mechanisms:

* Updated `collections`, `collection`, `svg_path`, and `css` functions to use `functools.lru_cache` with a default max size of 128 in `src/pyconify/api.py`. [[1]](diffhunk://#diff-bfad59b819eaf6adfc5621a95af6c513549596e04a69a159165b1d0ca4746772L49-R92) [[2]](diffhunk://#diff-bfad59b819eaf6adfc5621a95af6c513549596e04a69a159165b1d0ca4746772L70-R113) [[3]](diffhunk://#diff-bfad59b819eaf6adfc5621a95af6c513549596e04a69a159165b1d0ca4746772L263-R306) [[4]](diffhunk://#diff-bfad59b819eaf6adfc5621a95af6c513549596e04a69a159165b1d0ca4746772L330-R373)

### Tests:

* Added `test_clear_api_cache` to verify the functionality of the new cache-related functions in `tests/test_pyconify.py`.

### Imports and type annotations:

* Added `Any`, `Protocol`, and `cast` imports to support the new cache functionalities in `src/pyconify/api.py`. [[1]](diffhunk://#diff-bfad59b819eaf6adfc5621a95af6c513549596e04a69a159165b1d0ca4746772L13-R13) [[2]](diffhunk://#diff-bfad59b819eaf6adfc5621a95af6c513549596e04a69a159165b1d0ca4746772R23-R27)

### Module exports:

* Updated `__init__.py` to export the new `clear_api_cache` and `set_api_cache_maxsize` functions. [[1]](diffhunk://#diff-600b0341cfbe4fd570005a08d5a92b7ba7e9aa8a079439fa0dd7fb09eb8854f0R13) [[2]](diffhunk://#diff-600b0341cfbe4fd570005a08d5a92b7ba7e9aa8a079439fa0dd7fb09eb8854f0R25-R32) [[3]](diffhunk://#diff-600b0341cfbe4fd570005a08d5a92b7ba7e9aa8a079439fa0dd7fb09eb8854f0R41)